### PR TITLE
 Backwards-compatible enhancements to add optional context and verbose logger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: go
+go:
+- "1.2.x"
+- "1.3.x"
+- "1.4.x"
+- "1.5.x"
+- "1.6.x"
+- "1.7.x"
+- "1.8.x"
+- "1.9.x"
+- "1.10.x"
+- stable
+- master
+before_install:
+- go get gopkg.in/check.v1
+scripts:
+- make test
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: go
 go:
-- "1.2.x"
-- "1.3.x"
-- "1.4.x"
-- "1.5.x"
-- "1.6.x"
 - "1.7.x"
 - "1.8.x"
 - "1.9.x"
@@ -13,6 +8,8 @@ go:
 - master
 before_install:
 - go get gopkg.in/check.v1
+- mkdir -p vendor/gopkg.in
+- ln -s $(pwd) vendor/gopkg.in/pipe.v2
 scripts:
 - make test
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+test:
+	go test -v -cover
+
+vet:
+	go vet
+
+lint:
+	golint -set_exit_status
+	gofmt -s -d *.go
+

--- a/README.md
+++ b/README.md
@@ -2,3 +2,13 @@ Installation and usage
 ----------------------
 
 See [gopkg.in/pipe.v2](https://gopkg.in/pipe.v2) for documentation and usage details.
+
+[![Build status][travis-img]][travis-url] [![License][license-img]][license-url] [![GoDoc][godoc-img]][godoc-url]
+
+[travis-img]: https://img.shields.io/travis/steampunkcoder/pipe.svg?style=flat-square
+[travis-url]: https://travis-ci.org/steampunkcoder/pipe
+[license-img]: https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square
+[license-url]: LICENSE
+[godoc-img]: https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square
+[godoc-url]: https://godoc.org/github.com/steampunkcoder/pipe
+

--- a/mocklogger_test.go
+++ b/mocklogger_test.go
@@ -1,0 +1,26 @@
+package pipe_test
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MockLogger mocks interface pipe.StdLogger
+type MockLogger []string
+
+// Printf implements pipe.StdLogger interface for MockLogger
+func (mock *MockLogger) Printf(format string, v ...interface{}) {
+	mock.appendToLog(fmt.Sprintf(format, v...))
+}
+
+// Println implements pipe.StdLogger interface for MockLogger
+func (mock *MockLogger) Println(v ...interface{}) {
+	mock.appendToLog(fmt.Sprintln(v...))
+}
+
+func (mock *MockLogger) appendToLog(loggedStr string) {
+	if !strings.HasSuffix(loggedStr, "\n") {
+		loggedStr = loggedStr + "\n"
+	}
+	*mock = append(*mock, loggedStr)
+}


### PR DESCRIPTION
Backwards-compatible enhancements to add optional context and verbose logger
Add pipe.Sleep(), pipe.Reduce(), pipe.CountLines()
Add Makefile, .travis.yml
Minor updates for lint and UT fix